### PR TITLE
商品の詳細ページ実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,10 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def create
     @item = Item.new(item_params)
     if @item.save

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
     <% if @items %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to '#' do%>
+        <%= link_to item_path(item.id), method: :get do%>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
           <%# <div class='sold-out'><span>Sold Out!!</span></div> %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -22,48 +22,50 @@
         (税込) 送料込み
       </span>
     </div>
+    <% if user_signed_in? %>
+    
+      <% if user_signed_in? && current_user.id == @item.user_id %>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% if user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.introduction %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage_type.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.preparation_day.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
[What]
商品の詳細ページ実装

[Why]
コントローラーのshowアクションを定義
詳細ページへのpathを設置
deviseのヘルパーメソッドを用いて、
ログイン時、出品したユーザー以外のみ購入画面が表示される
出品者のみ編集、削除画面が表示される、という機能を実装しました


[出品した商品だった場合、編集と削除ボタンが出現する]
https://gyazo.com/911479ab157439fd3dc904649e8a0387

[他人の商品を閲覧した場合購入ボタンが出現する]
https://gyazo.com/cd5eea1126e288c9526be62e2a8a6969

[未ログイン時詳細のみが表示される]
https://gyazo.com/02bb3b54fc1fd4dd127a7096bc22977b
